### PR TITLE
jf - create database table for UCSBDiningCommonsMenuItems

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This is a JPA entity that represents a UCSBDiningCommonsMenuItem
+ *
+ * <p>A UCSBDiningCommonsMenuItem is a menu item at a UCSB dining commons
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitems")
+public class UCSBDiningCommonsMenuItem {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,0 +1,14 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBDiningCommonsMenuItemRepository is a repository for UCSBDiningCommonsMenuItem entities
+ */
+@Repository
+@RepositoryRestResource(exported = false)
+public interface UCSBDiningCommonsMenuItemRepository
+    extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {}

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItems.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItems.json
@@ -35,7 +35,7 @@
                   },
                   {
                     "column": {
-                      "name": "DININGCOMMONSCODE",
+                      "name": "DINING_COMMONS_CODE",
                       "type": "VARCHAR(255)"
                     }
                   },

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItems.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItems.json
@@ -1,0 +1,62 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "UCSBDiningCommonsMenuItems-1",
+          "author": "just-in-fan",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBDININGCOMMONSMENUITEMS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "UCSBDININGCOMMONSMENUITEMS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DININGCOMMONSCODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "UCSBDININGCOMMONSMENUITEMS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Closes #8

In this PR, we add a database table that represents UCSBDiningCommonsMenuItems, with the following fields:
```
long id;
String diningCommonsCode;
String name;
String station;
```

You can test this by running on localhost and looking for the UCSBDININGCOMMONSMENUITEMS table on the h2-console

<img width="416" height="358" alt="image" src="https://github.com/user-attachments/assets/22744387-705c-47d5-8545-4c3f3fba6f3f" />

You can also test this by running on dokku and connecting to the postgres database and running \dt

```
justinfan@dokku-02:~$ dokku postgres:connect team01-just-in-fan-db
psql (15.2 (Debian 15.2-1.pgdg110+1))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

team01_just_in_fan_db=# \dt
                   List of relations
 Schema |            Name            | Type  |  Owner
--------+----------------------------+-------+----------
 public | databasechangelog          | table | postgres
 public | databasechangeloglock      | table | postgres
 public | jobs                       | table | postgres
 public | restaurants                | table | postgres
 public | ucsbdates                  | table | postgres
 public | ucsbdiningcommons          | table | postgres
 public | ucsbdiningcommonsmenuitems | table | postgres
 public | urls                       | table | postgres
 public | users                      | table | postgres
(9 rows)
```