### PR TITLE
Kevin ucsb organization create db

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,20 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsborganization")
+public class UCSBOrganization {
+  @Id private String orgCode;
+  private String orgTranslationShort;
+  private String orgTranslation;
+  private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,10 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RepositoryRestResource(exported = false)
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {}

--- a/src/main/resources/db/migration/changes/UCSBOrganization.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganization.json
@@ -28,19 +28,19 @@
                       "primaryKey": true,
                       "primaryKeyName": "UCSBORGANIZATION_PK"
                     },
-                    "name": "ORGCODE",
+                    "name": "ORG_CODE",
                     "type": "VARCHAR(255)"
                   }
                 },
                 {
                   "column": {
-                    "name": "ORGTRANSLATIONSHORT",
+                    "name": "ORG_TRANSLATION_SHORT",
                     "type": "VARCHAR(255)"
                   }
                 },
                 {
                   "column": {
-                    "name": "ORGTRANSLATION",
+                    "name": "ORG_TRANSLATION",
                     "type": "VARCHAR(255)"
                   }
                 },

--- a/src/main/resources/db/migration/changes/UCSBOrganization.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganization.json
@@ -34,13 +34,13 @@
                 },
                 {
                   "column": {
-                    "name": "ORG_TRANSLATION_SHORT",
+                    "name": "ORGTRANSLATIONSHORT",
                     "type": "VARCHAR(255)"
                   }
                 },
                 {
                   "column": {
-                    "name": "ORG_TRANSLATION",
+                    "name": "ORGTRANSLATION",
                     "type": "VARCHAR(255)"
                   }
                 },

--- a/src/main/resources/db/migration/changes/UCSBOrganization.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganization.json
@@ -34,13 +34,13 @@
                 },
                 {
                   "column": {
-                    "name": "ORGTRANSLATIONSHORT",
+                    "name": "ORG_TRANSLATION_SHORT",
                     "type": "VARCHAR(255)"
                   }
                 },
                 {
                   "column": {
-                    "name": "ORGTRANSLATION",
+                    "name": "ORG_TRANSLATION",
                     "type": "VARCHAR(255)"
                   }
                 },

--- a/src/main/resources/db/migration/changes/UCSBOrganization.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganization.json
@@ -1,0 +1,64 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "UCSBOrganization-1",
+        "author": "makkerel",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "UCSBORGANIZATION"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "UCSBORGANIZATION_PK"
+                    },
+                    "name": "ORGCODE",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ORGTRANSLATIONSHORT",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ORGTRANSLATION",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "INACTIVE",
+                    "type": "BOOLEAN"
+                  }
+                }
+              ],
+              "tableName": "UCSBORGANIZATION"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #14 

In this PR, we add a database table for UCSB Organization with the following fields 
```
String orgCode
String orgTranslationShort
String orgTranslation
boolean inactive
```

You can test this by running on localhost and looking for the UCSBOrganization table on the h2-console
<img width="302" height="237" alt="Screenshot From 2026-04-22 20-50-21" src="https://github.com/user-attachments/assets/557a1b87-148e-41c4-ad94-18c08b9e6529" />

You can also check on dokku with with `dokku postgres:connect team01-dev-makkerel-db` and then typing `\dt`
```
kevinzhao@dokku-02:~$ dokku postgres:connect team01-dev-makkerel-db
psql (15.2 (Debian 15.2-1.pgdg110+1))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

team01_dev_makkerel_db=# \dt
                 List of relations
 Schema |         Name          | Type  |  Owner
--------+-----------------------+-------+----------
 public | databasechangelog     | table | postgres
 public | databasechangeloglock | table | postgres
 public | jobs                  | table | postgres
 public | restaurants           | table | postgres
 public | ucsbdates             | table | postgres
 public | ucsbdiningcommons     | table | postgres
 public | ucsborganization      | table | postgres
 public | urls                  | table | postgres
 public | users                 | table | postgres
(9 rows)
````