### PR TITLE
added PUT to edit a UCSB organization

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -6,11 +6,14 @@ import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -66,7 +69,7 @@ public class UCSBOrganizationController extends ApiController {
   }
 
   /**
-   * This method returns a single diningcommons.
+   * This method returns a single Organization.
    *
    * @param orgCode code of the Organization
    * @return a single Organization
@@ -80,5 +83,33 @@ public class UCSBOrganizationController extends ApiController {
             .findById(orgCode)
             .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
     return commons;
+  }
+
+  /**
+   * Update a single Organization. Accessible only to users with the role "ROLE_ADMIN".
+   *
+   * @param orgCode code of the organization
+   * @param incoming the new organization information
+   * @return the updated organization object
+   */
+  @Operation(summary = "Update a single organization")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public UCSBOrganization updateOrganization(
+      @Parameter(name = "orgCode") @RequestParam String orgCode,
+      @RequestBody @Valid UCSBOrganization incoming) {
+
+    UCSBOrganization organization =
+        ucsbOrganizationRepository
+            .findById(orgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+    organization.setOrgTranslationShort(incoming.getOrgTranslationShort());
+    organization.setOrgTranslation(incoming.getOrgTranslation());
+    organization.setInactive(incoming.getInactive());
+
+    ucsbOrganizationRepository.save(organization);
+
+    return organization;
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
@@ -189,6 +190,78 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     verify(ucsbOrganizationRepository, times(1)).findById(eq("CHS"));
     Map<String, Object> json = responseToJson(response);
     assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UCSBOrganization with id CHS not found", json.get("message"));
+  }
+
+  // Tests for PUT for an organization
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_organization() throws Exception {
+    UCSBOrganization mahjongOrig =
+        UCSBOrganization.builder()
+            .orgCode("MHJ")
+            .orgTranslationShort("Mahjong Club")
+            .orgTranslation("Asian Board Games Club")
+            .inactive(true)
+            .build();
+    UCSBOrganization mahjongEdit =
+        UCSBOrganization.builder()
+            .orgCode("MHJ")
+            .orgTranslationShort("Mahjong Club 2")
+            .orgTranslation("Asian Board Games Club 2")
+            .inactive(false)
+            .build();
+
+    when(ucsbOrganizationRepository.findById(eq("MHJ"))).thenReturn(Optional.of(mahjongOrig));
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/ucsborganization")
+                    .param("orgCode", "MHJ")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(mapper.writeValueAsString(mahjongEdit))
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+    verify(ucsbOrganizationRepository, times(1)).findById("MHJ");
+    verify(ucsbOrganizationRepository, times(1)).save(mahjongEdit);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(mapper.writeValueAsString(mahjongEdit), responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_organization_that_does_not_exist() throws Exception {
+    UCSBOrganization chessEdit =
+        UCSBOrganization.builder()
+            .orgCode("CHS")
+            .orgTranslationShort("Chess Club 2")
+            .orgTranslation("Super Chess Club 2")
+            .inactive(true)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(chessEdit);
+
+    when(ucsbOrganizationRepository.findById(eq("CHS"))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/ucsborganization")
+                    .param("orgCode", "CHS")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(ucsbOrganizationRepository, times(1)).findById("CHS");
+    Map<String, Object> json = responseToJson(response);
     assertEquals("UCSBOrganization with id CHS not found", json.get("message"));
   }
 }


### PR DESCRIPTION
Closes #17 

In this PR we add the `PUT` endpoint that allows an admin edit an existing entry organization in the database. Also fixes an error I didn't catch in the javadoc documentation for `GET` by Id
<img width="1802" height="931" alt="Screenshot From 2026-04-23 18-05-33" src="https://github.com/user-attachments/assets/28af5a65-429c-4bdd-b173-bf96b57e34e0" />
