### PR TITLE
Created a database table for menuitemreview - Kai

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -1,0 +1,28 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "menuitemreview")
+public class MenuItemReview {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private long itemId;
+  private String reviewerEmail;
+  private int stars;
+  private LocalDateTime dateReviewed;
+  private String comments;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
@@ -1,0 +1,10 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RepositoryRestResource(exported = false)
+public interface MenuItemReviewRepository extends CrudRepository<MenuItemReview, Long> {}

--- a/src/main/resources/db/migration/changes/MenuItemReview.json
+++ b/src/main/resources/db/migration/changes/MenuItemReview.json
@@ -35,7 +35,7 @@
                   },
                   {
                     "column": {
-                      "name": "ITEMID",
+                      "name": "ITEM_ID",
                       "type": "BIGINT"
                     }
                   },

--- a/src/main/resources/db/migration/changes/MenuItemReview.json
+++ b/src/main/resources/db/migration/changes/MenuItemReview.json
@@ -1,0 +1,74 @@
+  {
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "MenuItemReview-1",
+          "author": "KawaiiKai132",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "menuitemreview"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "MENUITEMREVIEW_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ITEMID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REVIEWER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STARS",
+                      "type": "INT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_REVIEWED",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "COMMENTS",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "menuitemreview"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Closes #26  

In this PR, I have added a database table for MenuItemReview with the fields
private long id;

  private long itemId;
  private String reviewerEmail;
  private int stars;
  private LocalDateTime dateReviewed;
  private String comments;
  
<img width="228" height="180" alt="image" src="https://github.com/user-attachments/assets/f2ecf768-eeaf-4e1a-8844-5e18a080b9f0" />

   Schema |            Name            | Type  |  Owner   
--------+----------------------------+-------+----------
 public | databasechangelog          | table | postgres
 public | databasechangeloglock      | table | postgres
 public | helprequests               | table | postgres
 public | jobs                       | table | postgres
 public | menuitemreview             | table | postgres
 public | restaurants                | table | postgres
 public | ucsbdates                  | table | postgres

